### PR TITLE
Fedora CoreOS install script on Raspberry Pi.

### DIFF
--- a/1-bake-fedora.sh
+++ b/1-bake-fedora.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e  # Exit immediately if a command exits with a non-zero status.
+set -x  # Print commands and their arguments as they are executed.
+
+# Check if the correct number of arguments is provided
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <FCOSDISK> <IGN_FILEPATH> <HOSTNAME>"
+    exit 1
+fi
+
+FCOSDISK="$1"
+IGN_FILEPATH="$2"
+HOSTNAME="$3"
+STREAM=stable  # or `next` or `testing`
+
+# Hot-swap the hostname
+tmp_ign_file=$(mktemp)
+trap 'rm -f "$tmp_ign_file"' EXIT
+encoded_hostname=$(printf "%s" "$HOSTNAME" | jq -sRr @uri)
+jq --arg new_hostname "data:,$encoded_hostname" \
+    'walk(if type == "object" and .path == "/etc/hostname" then .contents.source = $new_hostname else . end)' \
+    "$IGN_FILEPATH" > "$tmp_ign_file"
+
+# Create the partitions on the target disk
+sudo coreos-installer install -a aarch64 -s "$STREAM" -i "$tmp_ign_file" "$FCOSDISK"

--- a/2-install-rpi4-firmware.sh
+++ b/2-install-rpi4-firmware.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e  # Exit immediately if a command exits with a non-zero status.
+set -x  # Debugging mode
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <FCOSDISK>"
+    exit 1
+fi
+
+FCOSDISK="$1"
+
+FCOSEFIPARTITION=$(lsblk "$FCOSDISK" -J -oLABEL,PATH  | jq -r '.blockdevices[] | select(.label == "EFI-SYSTEM")'.path)
+BOOTPARTITION=$(lsblk "$FCOSDISK" -J -oLABEL,PATH  | jq -r '.blockdevices[] | select(.label == "boot")'.path)
+TEMP_DIR=$(mktemp -d)
+
+# Unmount any mounted partitions
+PARTITIONS=$(lsblk -pln "$FCOSDISK" -o NAME | grep -oP '^/dev/[^ ]+')
+for partition in $PARTITIONS; do
+    if mountpoint -q "$partition"; then
+        sudo umount "$partition"
+    fi
+done
+
+# Add the UEFI firmware
+sudo mount "$FCOSEFIPARTITION" "$TEMP_DIR" 
+trap 'sudo umount "$TEMP_DIR" || true; rm -rf "$TEMP_DIR"' EXIT
+pushd "$TEMP_DIR"
+VERSION=v1.34  # use latest one from https://github.com/pftf/RPi4/releases
+sudo curl -LO "https://github.com/pftf/RPi4/releases/download/${VERSION}/RPi4_UEFI_Firmware_${VERSION}.zip" \
+&& sudo unzip "RPi4_UEFI_Firmware_${VERSION}.zip" \
+&& sudo rm "RPi4_UEFI_Firmware_${VERSION}.zip"
+popd
+
+# Fix the boot hang bug with tune2fs on the the boot partition
+sudo e2fsck -f "$BOOTPARTITION"
+sudo tune2fs -U random "$BOOTPARTITION"

--- a/mvp.bu
+++ b/mvp.bu
@@ -1,0 +1,16 @@
+# To transpile:
+# butane -pso mvp.ign mvp.bu
+
+variant: fcos
+version: 1.4.0
+passwd:
+  users:
+  - name: core
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHWev7P63gEwqGm6TNGd5Dpydp5TKZpKIwIdfCjx88l james@kananlabs.org
+storage:
+  files:
+    - path: /etc/hostname
+      mode: 0644
+      contents:
+        inline: localhost

--- a/mvp.ign
+++ b/mvp.ign
@@ -1,0 +1,27 @@
+{
+  "ignition": {
+    "version": "3.3.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHWev7P63gEwqGm6TNGd5Dpydp5TKZpKIwIdfCjx88l james@kananlabs.org"
+        ]
+      }
+    ]
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/hostname",
+        "contents": {
+          "compression": "",
+          "source": "data:,localhost"
+        },
+        "mode": 420
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Provides a bare-bones butane/ignition configuration and scripts for creating bootable media targeted to the Raspberry Pi 4.